### PR TITLE
Added AI suggestion and user option to contact tutor via email

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -729,7 +729,31 @@ sidebar .admin-menu {
   border-radius: 0;
 }
 
+/* for send email */
+.email-prompt {
+  margin-top: 10px; /* Adds space between the message and the prompt */
+  padding: 10px; /* Adds padding around the prompt */
+  background-color: var(--color-light-grey); /* Light background for better visibility */
+  border-top: 1px solid var(--color-dark-blue); /* Adds a separator line at the top */
+}
 
+.email-prompt p {
+  margin-bottom: 10px; /* Adds space between the prompt text and the link */
+}
+
+.email-button {
+  padding: 10px 20px; /* Padding inside the button for a larger clickable area */
+  background-color: var(--color-dark-blue); /* Make the button color align with your theme */
+  color: var(--color-white); /* Button text color */
+  text-decoration: none; /* Remove underline from link */
+  display: inline-block; /* Ensures the button behaves like a block element */
+}
+
+.email-button:hover {
+  background-color: var(--color-dark-grey); /* Change color on hover */
+  color: var(--color-white); /* Text color change on hover */
+  text-decoration: none;
+}
 
 /* Style for the tooltip icon */
 .tooltip-icon {

--- a/routes/conversation.js
+++ b/routes/conversation.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { ensureAuthenticated, verifyConversationMiddleware, setActiveInstance, canAccessInstance, canAdminInstance } from '../middleware/auth.js'; // Import your middleware functions
-import { getConversation, getConversations, createConversation, getMessages, deleteConversation, updateConversation, postMessage, setRating } from '../controllers/conversation.js'; // Import necessary functions from controllers
+import { getConversation, getConversations, createConversation, getMessages, deleteConversation, updateConversation, postMessage, setRating, emailTutor } from '../controllers/conversation.js'; // Import necessary functions from controllers
 
 const router = express.Router({ mergeParams: true });
 
@@ -41,5 +41,8 @@ router.post("/:conversationId/messages", ensureAuthenticated, verifyConversation
 
 // Route to post a rating to a specific message
 router.post("/:conversationId/messages/:messageId", ensureAuthenticated, verifyConversationMiddleware, canAccessInstance, setRating);
+
+// Route to contact tutor via email
+router.get("/:conversationId/email", ensureAuthenticated, verifyConversationMiddleware, canAccessInstance, emailTutor);
 
 export default router;

--- a/views/pages/chat.ejs
+++ b/views/pages/chat.ejs
@@ -14,6 +14,8 @@
                     <input type="hidden" id="conversationId" value="<%- conversation.id %>"></input>
                     <textarea id="txt" placeholder="Send a message" name="msg" rows="1"></textarea>
                     <button type="submit" class="uil uil-message"></button>
+                    <p> | </p>
+                    <button type="button"  id="contact-tutor" class="uil uil-envelope-alt email"></button>
                 </div>
             </div>
         </div>
@@ -25,6 +27,7 @@
 
             const textarea = document.getElementById('txt');
             const form = document.querySelector('.aichat');
+            const contactTutorButton = document.getElementById('contact-tutor'); 
 
             textarea.addEventListener('input', function() {
                 this.style.height = 'auto'; // Reset the height
@@ -46,6 +49,10 @@
             });
 
             form.addEventListener('submit', handleSubmit); // Ensure the form calls handleSubmit on submit
+
+            contactTutorButton.addEventListener('click', function() {
+                contactTutor(form); // Call contactTutor when the button is clicked
+            });
         });
     </script>
 <%- include('../partials/footer') %>


### PR DESCRIPTION
- Implemented AI and User feature to suggest contacting a tutor based on conversation context.
- Updated UI to position the "contact tutor (email icon)" button next to message input (user trigger) and "send email to tutor" in the AI response message div (AI trigger).
- Handled confirmation prompt before sending an email to the tutor.

*** David can you check and sort out the tutor's email address? Do we want an email address added when we create an assistant/instance (sort of a "course convenor's email" that we can pull and use for tutor email) or do we want the user to add the tutor's email manually when the email is generated?